### PR TITLE
Upgrade to Express SDK 3 and add mobile SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Stormpath SPA Development Server
 
-
 [![NPM Version](https://img.shields.io/npm/v/stormpath-spa-dev-server.svg?style=flat)](https://npmjs.org/package/stormpath-spa-dev-server)
 [![NPM Downloads](http://img.shields.io/npm/dm/stormpath-spa-dev-server.svg?style=flat)](https://npmjs.org/package/stormpath-spa-dev-server)
 
-[Stormpath](https://stormpath.com/) development server that provides your SPA app with a Stormpath integrated back-end.
+[Stormpath](https://stormpath.com/) development server that provides your SPA or mobile app with a Stormpath integrated back-end.
 
 Front-end applications can not communicate with the Stormpath API directly, and thus need an integrated back-end. Before your back-end has been integrated, use this development server when integrating Stormpath with your front-end app, using for example the [AngularJS SDK](https://github.com/stormpath/stormpath-sdk-angularjs).
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "stormpath-spa-dev-server",
   "version": "1.0.1",
-  "description": "Stormpath development server that provides your SPA app with a Stormpath integrated back-end.",
+  "description": "Stormpath development server that provides your SPA or mobile app with a Stormpath integrated back-end.",
   "main": "server.js",
   "bin": {
     "stormpath-spa-dev-server": "server.js"
   },
   "dependencies": {
-    "express": "^4.13.3",
-    "express-stormpath": "2.4.0"
+    "express": "^4.13.4",
+    "express-stormpath": "3.1.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -7,64 +7,53 @@ var stormpath = require('express-stormpath');
 var path = require('path');
 var fs = require('fs');
 
+var SPA_ROOT = process.argv[2]; // The path to the SPA app to serve.
 var app = express();
-
-var SPA_ROOT = process.argv[2]; // The path to the SPA app to serve
 
 function isValidPath(path) {
   try {
     return path && fs.lstatSync(SPA_ROOT).isDirectory() === true;
-  } catch(error) {
+  } catch (error) {
     return false;
   }
 }
 
-if (!isValidPath(SPA_ROOT)) {
-  console.error('Error: First argument must be a valid path to your SPA app.');
-  return 1;
+if (SPA_ROOT) {
+  if (!isValidPath(SPA_ROOT)) {
+    console.error('Error: First argument must be a valid path to your SPA app.');
+    return 1;
+  }
 }
 
 app.use(stormpath.init(app, {
   web: {
-    login: {
-      enabled: true
-    },
-    logout: {
-      enabled: true
-    },
-    register: {
-      enabled: true
-    },
+    produces: ['application/json'],
     me: {
-      enabled: true
-    },
-    spaRoot: path.join(SPA_ROOT, 'index.html')
+      expand: {
+        customData: true,
+        groups: true,
+        groupMemberships: true
+      }
+    }
   }
 }));
 
-app.use(express.static(SPA_ROOT));
+if (SPA_ROOT) {
+  app.use(express.static(SPA_ROOT));
 
-// Example of a protected route which requires login
-app.get('/secret', stormpath.loginRequired, function(req, res) {
-  /*
-    If we get here, the user is logged in. Otherwise, they
-    were redirected to the login page
-   */
-  res.send({ result: true });
-});
+  // All undefined asset or api routes should return a 404.
+  app.route('/:url(api|auth|components|app|bower_components|assets)/*').get(function (req, res) {
+    res.status(404).end();
+  });
 
-// All undefined asset or api routes should return a 404
-app.route('/:url(api|auth|components|app|bower_components|assets)/*').get(function(req, res) {
-  res.status(404).end();
-});
+  // All other routes should redirect to the index.html.
+  app.route('/*').get(function (req, res) {
+    res.sendFile(path.join(SPA_ROOT, 'index.html'));
+  });
+}
 
-// All other routes should redirect to the index.html
-app.route('/*').get(function(req, res) {
-  res.sendFile(path.join(SPA_ROOT, 'index.html'));
-});
-
-app.on('stormpath.ready', function() {
-  app.listen(3000, function() {
-    console.log('Stormpath SPA Development Server listening at http://localhost:3000');
+app.on('stormpath.ready', function () {
+  app.listen(3000, function () {
+    console.log('Stormpath SPA Development Server listening at http://localhost:3000.');
   });
 });


### PR DESCRIPTION
This PR upgrades the code to use the latest version of the Express SDK (`v.3.1.0`) and also adds the option to not serve an SPA. This way it can also be used together with the mobile SDKs.
### Discussion

We should maybe rename this server to not include _SPA_ anymore as it can be used for mobile apps and other front-end types?
### How to verify
1. Checkout this branch
2. Run `node server`
3. Using e.g. Postman, verify that you can get the login view model, etc.
4. Try to serve the Angular Dashboard example: `node server ~/Projects/stormpath/stormpath-sdk-angularjs/example/dashboard-app/client/`
5. Verify that the Angular app is served at http://localhost:3000 and that the API still works
