### PR TITLE
Release 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stormpath-spa-dev-server",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Stormpath development server that provides your SPA or mobile app with a Stormpath integrated back-end.",
   "main": "server.js",
   "bin": {


### PR DESCRIPTION
Release version `1.1.0` that includes the option to not serve any SPA and just use it as an API mock server. It also upgrades to express-stormpath version `3.1.1`.
